### PR TITLE
Lint recipe for version 0.2.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  mesters_org: django_dev

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  mesters_org: django_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - patch # [unix]
+    - m2-patch # [win]
   host:
     - backports
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 5
-  skip: true  # [py>39]
+  skip: true  # [py>38]
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ about:
 
   description: |
     Backport of the standard library zoneinfo module
-  doc_url: https://zoneinfo.readthedocs.io/en/latest/
+  doc_url: https://zoneinfo.readthedocs.io/
   dev_url: https://github.com/pganssle/zoneinfo
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
+    - patch # [unix]
   host:
     - backports
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - tzdata-location.patch
 
 build:
-  number: 5
+  number: 6
   skip: true  # [py>38]
   script: "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - {{ compiler('c') }}
     - m2-patch # [win]
     - patch # [not win]
-    - setuptools >= 40.0.0
+    - setuptools >=40.0.0
     - wheel
   host:
     - backports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,6 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
     - patch # [unix]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - patch # [unix]
+    - patch # [not win]
     - m2-patch # [win]
   host:
     - backports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ about:
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
+  license_url: https://www.apache.org/licenses/LICENSE-2.0
   summary: 'Backport of the standard library zoneinfo module'
 
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - tzdata-location.patch
 
 build:
-  number: 6
+  number: 0
   skip: true  # [py>38]
   script: "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,10 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - patch # [not win]
     - m2-patch # [win]
+    - patch # [not win]
+    - setuptools >= 40.0.0
+    - wheel
   host:
     - backports
     - python


### PR DESCRIPTION
Initial PR for this feedstock to get it onto Zeus.

This is a dependency for django 4 (ticket [DSNC-4153](https://anaconda.atlassian.net/browse/DSNC-4153)).

# Package Info

Home: https://github.com/pganssle/zoneinfo
Source: https://github.com/pganssle/zoneinfo/archive/refs/tags/0.2.1.tar.gz
Documentation: https://zoneinfo.readthedocs.io

# Actions

* Add URL to licemse
* Remove localization of the doc URL
* Remove python 3.9 support since upstream only supports up to 3.8
* Fix build requirements